### PR TITLE
build: Separate commands in recovery foreach loops

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -915,11 +915,11 @@ $(recovery_ramdisk): $(MKBOOTFS) $(MINIGZIP) $(RECOVERYIMAGE_EXTRA_DEPS) \
 	$(hide) cp -rf $(recovery_resources_common)/* $(TARGET_RECOVERY_ROOT_OUT)/res
 	$(hide) cp -f $(recovery_font) $(TARGET_RECOVERY_ROOT_OUT)/res/images/font.png
 	$(hide) $(foreach item,$(recovery_root_private), \
-	  cp -rf $(item) $(TARGET_RECOVERY_OUT)/)
+	  cp -rf $(item) $(TARGET_RECOVERY_OUT)/;)
 	$(hide) $(foreach item,$(recovery_resources_private), \
-	  cp -rf $(item) $(TARGET_RECOVERY_ROOT_OUT)/)
+	  cp -rf $(item) $(TARGET_RECOVERY_ROOT_OUT)/;)
 	$(hide) $(foreach item,$(recovery_fstab), \
-	  cp -f $(item) $(TARGET_RECOVERY_ROOT_OUT)/etc/recovery.fstab)
+	  cp -f $(item) $(TARGET_RECOVERY_ROOT_OUT)/etc/recovery.fstab;)
 	$(hide) cp $(RECOVERY_INSTALL_OTA_KEYS) $(TARGET_RECOVERY_ROOT_OUT)/res/keys
 	$(hide) cat $(INSTALLED_DEFAULT_PROP_TARGET) $(recovery_build_prop) \
 	        > $(TARGET_RECOVERY_ROOT_OUT)/default.prop


### PR DESCRIPTION
The foreach loops output a space separated list, not necessarily one
command per line. Separate commands with semicolons. Notably, this
fixes an issue with multiple device directories included in
TARGET_RECOVERY_DEVICE_DIRS.

Change-Id: I5ebdc84ecaaacabaea77b8b752141e2041622480
